### PR TITLE
feat: add webpack watch support for postcss files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const getBody = require('./lib/get-body');
 const getPostcssSources = require('./lib/get-postcss-sources');
 const processPostcss = require('./lib/process-postcss');
 const fixTemplate = require('./lib/fix-template');
+const fullPaths = require('./lib/full-paths');
 
 module.exports = function (source) {
   const cb = this.async();
@@ -20,6 +21,8 @@ module.exports = function (source) {
   const parsed = parse5.parse(source);
   const body = getBody(parsed);
   const sourcesFilePath = getPostcssSources(body);
+
+  fullPaths(sourcesFilePath, this.resourcePath).forEach(this.addDependency);
 
   postcssrc()
     .then(config => processPostcss(sourcesFilePath, htmlFilePath, config))

--- a/src/lib/full-paths.js
+++ b/src/lib/full-paths.js
@@ -1,0 +1,3 @@
+const fullPath = require('./full-path');
+
+module.exports = (fps, rp) => fps.map(fp => fullPath(fp, rp));

--- a/test/units/full-paths.test.js
+++ b/test/units/full-paths.test.js
@@ -1,0 +1,11 @@
+import {join} from 'path';
+import test from 'ava';
+import fullPaths from '../../src/lib/full-paths';
+
+test('fullPaths()', t => {
+  t.deepEqual(
+    fullPaths(['test.postcss', 'test2.postcss'], 'my/dir/file.html'),
+    [join('my', 'dir', 'test.postcss'), join('my', 'dir', 'test2.postcss')],
+    'should return the full paths of a sources array based on the path of the resource file'
+  );
+});


### PR DESCRIPTION
This PR adds webpack watch support for postcss files processed through this loader.